### PR TITLE
fixed link from k8s.gcr.io to registry.k8s.io registered.rs

### DIFF
--- a/src/states/registered.rs
+++ b/src/states/registered.rs
@@ -15,7 +15,7 @@ fn validate_pod_runnable(pod: &Pod) -> anyhow::Result<()> {
 
 fn validate_not_kube_proxy(container: &Container) -> anyhow::Result<()> {
     if let Some(image) = container.image()? {
-        if image.whole().starts_with("k8s.gcr.io/kube-proxy") {
+        if image.whole().starts_with("registry.k8s.io/kube-proxy") {
             return Err(anyhow::anyhow!("Cannot run kube-proxy"));
         }
     }


### PR DESCRIPTION
This PR fixes [Umbrella Issue] Migrate CNCF Ecosystem projects from k8s.gcr.io to registry.k8s.io
https://github.com/kubernetes/k8s.io/issues/4780